### PR TITLE
Correção em instrução do código do cedente em boleto, conforme doc.

### DIFF
--- a/BoletoBr/BoletoBr/Bancos/Sicoob/BancoSicoob.cs
+++ b/BoletoBr/BoletoBr/Bancos/Sicoob/BancoSicoob.cs
@@ -81,8 +81,8 @@ namespace BoletoBr.Bancos.Sicoob
 
             boleto.CedenteBoleto.CodigoCedenteFormatado = String.Format("{0}/{1}{2}",
                 boleto.CedenteBoleto.ContaBancariaCedente.Agencia.PadLeft(4, '0'),
-                boleto.CedenteBoleto.ContaBancariaCedente.Conta.PadLeft(7, '0'),
-                boleto.CedenteBoleto.ContaBancariaCedente.DigitoConta);
+                boleto.CedenteBoleto.CodigoCedente.PadLeft(7, '0'),
+                boleto.CedenteBoleto.DigitoCedente);
         }
 
         public void FormataCodigoBarra(Boleto boleto)


### PR DESCRIPTION
…Documentação do banco.

A instrução retornada para preenchimento do boleto conter
agencia/código do cedente.