### PR TITLE
Correção em instrução do código do cedente em boleto, conforme doc.

### DIFF
--- a/BoletoBr/BoletoBr.UnitTests/TestsBancos/BancoSicoobTests.cs
+++ b/BoletoBr/BoletoBr.UnitTests/TestsBancos/BancoSicoobTests.cs
@@ -159,6 +159,7 @@ namespace BoletoBr.UnitTests.TestsBancos
             const string codigoBarras = "75691699400000465821500401028796200001061001";
             Assert.AreEqual(boleto.CodigoBarraBoleto.Length, codigoBarras.Length);
             Assert.AreEqual(codigoBarras, boleto.CodigoBarraBoleto);
+			Assert.AreEqual(boleto.CedenteBoleto.CodigoCedenteFormatado, "5004/00287962");
         }
 
         [TestMethod]

--- a/BoletoBr/BoletoBr/Bancos/Sicoob/BancoSicoob.cs
+++ b/BoletoBr/BoletoBr/Bancos/Sicoob/BancoSicoob.cs
@@ -81,8 +81,8 @@ namespace BoletoBr.Bancos.Sicoob
 
             boleto.CedenteBoleto.CodigoCedenteFormatado = String.Format("{0}/{1}{2}",
                 boleto.CedenteBoleto.ContaBancariaCedente.Agencia.PadLeft(4, '0'),
-                boleto.CedenteBoleto.ContaBancariaCedente.Conta.PadLeft(7, '0'),
-                boleto.CedenteBoleto.ContaBancariaCedente.DigitoConta);
+                boleto.CedenteBoleto.CodigoCedente.PadLeft(7, '0'),
+                boleto.CedenteBoleto.DigitoCedente);
         }
 
         public void FormataCodigoBarra(Boleto boleto)


### PR DESCRIPTION
A instrução retornada para preenchimento do boleto deve conter
agencia/código do cedente.